### PR TITLE
Allow Error reporting for all Errors and Fatals logged

### DIFF
--- a/errorreporting_test.go
+++ b/errorreporting_test.go
@@ -20,3 +20,13 @@ func TestRecoverPanics(t *testing.T) {
 
 	panic("WOOT")
 }
+
+func TestInitErrorReporting(t *testing.T) {
+	err := InitErrorReporting(context.Background(), "hepp", "test", "v1.0")
+	if err != nil {
+		t.Errorf("Didn't expect an error, but got %s", err)
+	}
+	if errorClient == nil {
+		t.Errorf("Expected errorClient to be initialized, but it was nil")
+	}
+}

--- a/logger.go
+++ b/logger.go
@@ -49,6 +49,8 @@ func InitErrorReporting(ctx context.Context, projectID, serviceName, serviceVers
 	}
 
 	errorClient = client
+
+	return nil
 }
 
 // SetUpErrorReporting creates an ErrorReporting client and returns that client together with a reportPanics function.

--- a/logger.go
+++ b/logger.go
@@ -58,12 +58,9 @@ func InitErrorReporting(ctx context.Context, projectID, serviceName, serviceVers
 // Error Reporting
 func SetUpErrorReporting(ctx context.Context, projectID, serviceName, serviceVersion string) (client *errorreporting.Client, reportPanics func()) {
 	lgr := New("errorreporting")
-	errorClient, err := errorreporting.NewClient(ctx, projectID,
-		errorreporting.Config{
-			ServiceName:    serviceName,
-			ServiceVersion: serviceVersion})
-	if err != nil {
-		lgr.Fatal("Couldn't create an errorreporting client", err)
+	client, errClient := newErrorReportingClient(ctx, projectID, serviceName, serviceVersion)
+	if errClient != nil {
+		lgr.Fatal("Couldn't create an errorreporting client", errClient)
 	}
 	return errorClient, func() {
 		x := recover()


### PR DESCRIPTION
If invocating `InitErrorReporting` all errors and fatals logged will also report the error to Google Error Reporting.

Also updates deps