### PR TITLE
add forgotten '...' in logger.Fatal

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -222,7 +222,7 @@ func (ul unaLogger) Fatal(msg string, err error, args ...interface{}) {
 		// Logging at level Fatal without the panic since we have reported to Errorreporting already
 		ul.Logger.Log(log.LevelFatal, msg, appendErrorToArgs(args, err))
 	}
-	ul.Logger.Fatal(msg, appendErrorToArgs(args, err))
+	ul.Logger.Fatal(msg, appendErrorToArgs(args, err)...)
 }
 
 func appendErrorToArgs(args []interface{}, err error) []interface{} {


### PR DESCRIPTION
I've noticed that `log.Fatal(msg, err)` messages are actually missing the `err` in the logs.

For this code

    log := unalogger.New("yo")
    log.Fatal("hello", fmt.Errorf("world"))

I expected to see something like this in the output (which is what we get with this patch)

    17:31:34.004229 CRITICAL yo hello error: world

but instead I found this

    17:28:27.413387 CRITICAL yo hello _: [error map[]]


I noticed it works just fine for log.Error, and the only difference was the missing "...", causing the arguments slice to be interpreted as the first argument.

---
<!-- Please fill in your description above the --- -->
<!-- Protip, use a descriptive way such as https://cucumber.io/docs/gherkin/reference/ -->
Please read [using git](https://github.com/unacast/.github/blob/main/USING_GIT.md) and `contributing guidelines` ⤵️ before submitting code. (It's at the bottom of the page)
<img width="506" alt="Screenshot 2022-08-19 at 09 46 50" src="https://user-images.githubusercontent.com/4453/185570224-76924708-8f95-4409-8ebb-f373d0dfaa5f.png">
